### PR TITLE
Update homez.g

### DIFF
--- a/sys/homez.g
+++ b/sys/homez.g
@@ -1,6 +1,8 @@
 ; homez.g
 ; called to home the Z axis
 
+T-1       ;just in case there is a tool coupled, go try to drop it at the dock
+
 M98 P/macros/Coupler - Unlock	;Open Coupler
 
 G91 				; Relative mode


### PR DESCRIPTION
Before homing Z and if a tool is active, the TC should try to dock it first.

This will also effect the "homeall.g", because homez.g is called via M98 in it.