### PR TITLE
Update homeall.g

### DIFF
--- a/sys/homeall.g
+++ b/sys/homeall.g
@@ -9,4 +9,4 @@ M98 Phomex.g			; Home X
 
 M98 Phomez.g			; Home Z
 
-G1 X150 Y-49 F15000		; Park
+G1 X150 Y-47 F15000		; Park


### PR DESCRIPTION
changed park-position to not being Y-min-position, because Y-49 is Y-min and when homing Y when the head is at Y-49, homing can fail.