### PR TITLE
Update homex.g

### DIFF
--- a/sys/homex.g
+++ b/sys/homex.g
@@ -21,6 +21,5 @@ M400 			; make sure everything has stopped before we reset the motor currents
 G4 P100			; wait 100ms
 M913 X100 Y100 		; motor currents back to 100%
 
-M574 X1 S0 		; Define active low and unused microswitches
 
 


### PR DESCRIPTION
M574 command at the end of the homing script will overwrite the setting in config.g.
This is, because on my last commit, I requested to remove the initial M574 that did set up sensorless homing, but didn't saw the M574 command at the end, that also needed to be removed. Sorry.