### PR TITLE
Update bed.g

### DIFF
--- a/rrf2.x/sys/bed.g
+++ b/rrf2.x/sys/bed.g
@@ -2,6 +2,8 @@
 
 G28 Z
 
+G30
+
 G1 S2 Z3 F5000		; lift Z 3mm
 
 G29


### PR DESCRIPTION
switching G29 on and off in the toolchange-macros triggers a warning-message "Warning: the height map was loaded when the current Z=0 datum was not determined probing. This may result in a height offset."
The simplest solution to this I could find is to add a "G30" right after the "G28 Z". 
This was suggested by DC42 at https://forum.duet3d.com/topic/10835/z-0-datum-was-not-determined-probing